### PR TITLE
Fix variable extraction

### DIFF
--- a/thepipe/core.py
+++ b/thepipe/core.py
@@ -251,8 +251,7 @@ class Pipeline:
             if variables is not None:
                 for _, entries in config.items():
                     for key, value in entries.items():
-                        print(key, value)
-                        if value in variables:
+                        if isinstance(value, str) and value in variables:
                             entries[key] = variables[value]
         else:
             config = {}

--- a/thepipe/tests/test_core.py
+++ b/thepipe/tests/test_core.py
@@ -610,7 +610,8 @@ class TestPipelineConfigurationViaFile(TestCase):
                    b"FOO = 1\n"
                    b"[Narf]\n"
                    b"bar = 'FOO'\n"
-                   b"fjoord = 2")
+                   b"fjoord = 2\n"
+                   b"argh = [1, 2, 3]")
         fobj.flush()
         fname = str(fobj.name)
 


### PR DESCRIPTION
When variables contain non-hashable types, the variable extraction fails. This PR changes the inspection to only use string-type variables.